### PR TITLE
develop-ik-child-components: moved components inside parent app compo…

### DIFF
--- a/angular/develop-andrey/src/app/app.component.html
+++ b/angular/develop-andrey/src/app/app.component.html
@@ -17,4 +17,6 @@
     <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
-
+<!--HERE ARE COMPONENTS-->
+<app-my></app-my>
+<app-my2></app-my2>

--- a/angular/develop-andrey/src/app/app.module.ts
+++ b/angular/develop-andrey/src/app/app.module.ts
@@ -15,6 +15,6 @@ import { My2Component } from './my2/my2.component';
     BrowserModule
   ],
   providers: [],
-  bootstrap: [AppComponent, MyComponent, My2Component]
+  bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/angular/develop-andrey/src/index.html
+++ b/angular/develop-andrey/src/index.html
@@ -10,7 +10,5 @@
 </head>
 <body>
   <app-root></app-root>
-  <app-my></app-my>
-  <app-my2></app-my2>
 </body>
 </html>


### PR DESCRIPTION
Please take a look:
1) moved the following tags out from `index.html` into `app.component.html` (check two files: `index.html` and `app.component.html` below):
```  
  <app-my></app-my>
  <app-my2></app-my2>
```
2) and since MyComponent component (selector `app-my`) and My2Component component (selector `app-my2`) are now enclosed into parent AppComponent component (as childs) we do not bootstrap them and so we remove them from `bootstrap` property in `app.module.ts` file:
```
bootstrap: [AppComponent]
```